### PR TITLE
Fix WebSocket shutdown on activity restart

### DIFF
--- a/app/src/main/java/com/example/serveradminapp/LocaleUtil.java
+++ b/app/src/main/java/com/example/serveradminapp/LocaleUtil.java
@@ -50,10 +50,6 @@ public class LocaleUtil {
     /** Restart the given activity to apply configuration changes safely.
      *  Any active metrics WebSocket is closed so it can be recreated. */
     public static void restart(Activity activity) {
-        ServerApi api = ServerApi.get();
-        if (api != null) {
-            api.stopMetricsSocket();
-        }
         Intent intent = activity.getIntent();
         activity.finish();
         activity.startActivity(intent);

--- a/app/src/main/java/com/example/serveradminapp/MainActivity.java
+++ b/app/src/main/java/com/example/serveradminapp/MainActivity.java
@@ -82,7 +82,9 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        ServerApi.get().stopMetricsSocket();
+        if (isFinishing() && !isChangingConfigurations()) {
+            ServerApi.get().stopMetricsSocket();
+        }
         super.onDestroy();
     }
 }

--- a/app/src/main/java/com/example/serveradminapp/fragments/ChatsFragment.java
+++ b/app/src/main/java/com/example/serveradminapp/fragments/ChatsFragment.java
@@ -105,10 +105,12 @@ public class ChatsFragment extends Fragment {
         ServerApi.get().listSessions(new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() -> {
-                    chatList.clear();
-                    adapter.notifyDataSetChanged();
-                });
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() -> {
+                        chatList.clear();
+                        adapter.notifyDataSetChanged();
+                    });
+                }
             }
 
             @Override
@@ -122,7 +124,9 @@ public class ChatsFragment extends Fragment {
                     for (int i=0;i<arr.length();i++) {
                         chatList.add(arr.getJSONObject(i));
                     }
-                    requireActivity().runOnUiThread(() -> sortAndUpdate());
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() -> sortAndUpdate());
+                    }
                 } catch (JSONException ex) {
                     // ignore
                 }
@@ -178,7 +182,7 @@ public class ChatsFragment extends Fragment {
                     @Override public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {}
                     @Override public void onResponse(@NonNull okhttp3.Call call, @NonNull okhttp3.Response response) throws IOException {
                         response.close();
-                        if (response.isSuccessful()) {
+                        if (response.isSuccessful() && isAdded()) {
                             requireActivity().runOnUiThread(() -> {
                                 chatList.remove(obj);
                                 notifyDataSetChanged();

--- a/app/src/main/java/com/example/serveradminapp/fragments/DashboardFragment.java
+++ b/app/src/main/java/com/example/serveradminapp/fragments/DashboardFragment.java
@@ -111,16 +111,18 @@ public class DashboardFragment extends Fragment {
                     final int net = (int) Math.round(obj.optDouble("network"));
                     final int disk = (int) Math.round(obj.optDouble("disk"));
                     setStatusWork();
-                    requireActivity().runOnUiThread(() -> {
-                        if (day > 0)
-                            messages24hText.setText(getString(R.string.messages_24h_value, day));
-                        if (total > 0)
-                            messagesTotalText.setText(getString(R.string.messages_total_value, total));
-                        cpuGauge.setPercent(cpu);
-                        memGauge.setPercent(mem);
-                        netGauge.setPercent(net);
-                        diskGauge.setPercent(disk);
-                    });
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() -> {
+                            if (day > 0)
+                                messages24hText.setText(getString(R.string.messages_24h_value, day));
+                            if (total > 0)
+                                messagesTotalText.setText(getString(R.string.messages_total_value, total));
+                            cpuGauge.setPercent(cpu);
+                            memGauge.setPercent(mem);
+                            netGauge.setPercent(net);
+                            diskGauge.setPercent(disk);
+                        });
+                    }
                 } else if (obj.has("snapshot")) {
                     JSONObject snap = obj.getJSONObject("snapshot");
                     updateUsageFromJson(snap);
@@ -162,10 +164,12 @@ public class DashboardFragment extends Fragment {
         ServerApi.get().fetchUsage(new Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() -> {
-                    messages24hText.setText(R.string.messages_24h);
-                    messagesTotalText.setText(R.string.messages_total);
-                });
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() -> {
+                        messages24hText.setText(R.string.messages_24h);
+                        messagesTotalText.setText(R.string.messages_total);
+                    });
+                }
             }
 
             @Override
@@ -190,9 +194,11 @@ public class DashboardFragment extends Fragment {
         int totalCount = obj.optInt("total", dayCount);
         final int count24h = dayCount;
         final int countTotal = totalCount;
-        requireActivity().runOnUiThread(() -> {
-            messages24hText.setText(getString(R.string.messages_24h_value, count24h));
-            messagesTotalText.setText(getString(R.string.messages_total_value, countTotal));
-        });
+        if (isAdded()) {
+            requireActivity().runOnUiThread(() -> {
+                messages24hText.setText(getString(R.string.messages_24h_value, count24h));
+                messagesTotalText.setText(getString(R.string.messages_total_value, countTotal));
+            });
+        }
     }
 }

--- a/app/src/main/java/com/example/serveradminapp/fragments/ModelsFragment.java
+++ b/app/src/main/java/com/example/serveradminapp/fragments/ModelsFragment.java
@@ -104,8 +104,10 @@ public class ModelsFragment extends Fragment {
         ServerApi.get().listModels(new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed_load), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed_load), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override
@@ -123,7 +125,9 @@ public class ModelsFragment extends Fragment {
                     for (int i = 0; i < array.length(); i++) {
                         modelList.add(array.getString(i));
                     }
-                    requireActivity().runOnUiThread(() -> adapter.notifyDataSetChanged());
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() -> adapter.notifyDataSetChanged());
+                    }
                 } catch (JSONException ex) {
                     onFailure(call, new IOException(ex));
                 }
@@ -135,8 +139,10 @@ public class ModelsFragment extends Fragment {
         ServerApi.get().availableModels(new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override
@@ -154,7 +160,9 @@ public class ModelsFragment extends Fragment {
                     for (int i = 0; i < arr.length(); i++) {
                         availableList.add(arr.getString(i));
                     }
-                    requireActivity().runOnUiThread(() -> availableAdapter.notifyDataSetChanged());
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() -> availableAdapter.notifyDataSetChanged());
+                    }
                 } catch (JSONException ex) {
                     onFailure(call, new IOException(ex));
                 }
@@ -166,8 +174,10 @@ public class ModelsFragment extends Fragment {
         ServerApi.get().modelVariants(name, new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override
@@ -185,7 +195,9 @@ public class ModelsFragment extends Fragment {
                     for (int i = 0; i < arr.length(); i++) {
                         variantList.add(arr.getString(i));
                     }
-                    requireActivity().runOnUiThread(() -> variantAdapter.notifyDataSetChanged());
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() -> variantAdapter.notifyDataSetChanged());
+                    }
                 } catch (JSONException ex) {
                     onFailure(call, new IOException(ex));
                 }
@@ -225,14 +237,18 @@ public class ModelsFragment extends Fragment {
                             if ("success".equals(parsed)) {
                                 String name = installingVariant;
                                 installingVariant = null;
-                                requireActivity().runOnUiThread(() -> {
-                                    progressText.setText("");
-                                    android.widget.Toast.makeText(requireContext(),
-                                            "модель " + name + " успешно установлена",
-                                            android.widget.Toast.LENGTH_SHORT).show();
-                                });
+                                if (isAdded()) {
+                                    requireActivity().runOnUiThread(() -> {
+                                        progressText.setText("");
+                                        android.widget.Toast.makeText(requireContext(),
+                                                "модель " + name + " успешно установлена",
+                                                android.widget.Toast.LENGTH_SHORT).show();
+                                    });
+                                }
                             } else {
-                                requireActivity().runOnUiThread(() -> progressText.setText(parsed));
+                                if (isAdded()) {
+                                    requireActivity().runOnUiThread(() -> progressText.setText(parsed));
+                                }
                             }
                         }
                     } else if (obj.has("models")) {
@@ -241,16 +257,20 @@ public class ModelsFragment extends Fragment {
                         for (int i = 0; i < arr.length(); i++) {
                             modelList.add(arr.getString(i));
                         }
-                        requireActivity().runOnUiThread(() -> adapter.notifyDataSetChanged());
+                        if (isAdded()) {
+                            requireActivity().runOnUiThread(() -> adapter.notifyDataSetChanged());
+                        }
                         if (installingVariant != null) {
                             for (int i = 0; i < arr.length(); i++) {
                                 if (installingVariant.equals(arr.getString(i))) {
                                     final String name = installingVariant;
                                     installingVariant = null;
-                                    requireActivity().runOnUiThread(() -> android.widget.Toast.makeText(
-                                            requireContext(),
-                                            "модель " + name + " успешно установлена",
-                                            android.widget.Toast.LENGTH_SHORT).show());
+                                    if (isAdded()) {
+                                        requireActivity().runOnUiThread(() -> android.widget.Toast.makeText(
+                                                requireContext(),
+                                                "модель " + name + " успешно установлена",
+                                                android.widget.Toast.LENGTH_SHORT).show());
+                                    }
                                     break;
                                 }
                             }
@@ -308,8 +328,10 @@ public class ModelsFragment extends Fragment {
         ServerApi.get().deleteModel(name, new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.error), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.error), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override

--- a/app/src/main/java/com/example/serveradminapp/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/example/serveradminapp/fragments/SettingsFragment.java
@@ -87,8 +87,10 @@ public class SettingsFragment extends Fragment {
         ServerApi.get().loadConfig(new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed_load), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed_load), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override
@@ -102,10 +104,12 @@ public class SettingsFragment extends Fragment {
                 response.close();
                 try {
                     JSONObject obj = new JSONObject(body);
-                    requireActivity().runOnUiThread(() -> {
-                        portEdit.setText(obj.optString("port"));
-                        limitEdit.setText(obj.optString("daily_limit"));
-                    });
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() -> {
+                            portEdit.setText(obj.optString("port"));
+                            limitEdit.setText(obj.optString("daily_limit"));
+                        });
+                    }
                 } catch (JSONException ex) {
                     onFailure(call, new IOException(ex));
                 }
@@ -126,15 +130,19 @@ public class SettingsFragment extends Fragment {
         ServerApi.get().updateConfig(body, new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override
             public void onResponse(@NonNull okhttp3.Call call, @NonNull okhttp3.Response response) throws IOException {
                 response.close();
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), response.isSuccessful() ? getString(R.string.saved) : getString(R.string.error), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), response.isSuccessful() ? getString(R.string.saved) : getString(R.string.error), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
         });
     }
@@ -143,15 +151,19 @@ public class SettingsFragment extends Fragment {
         ServerApi.get().restartServer(new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override
             public void onResponse(@NonNull okhttp3.Call call, @NonNull okhttp3.Response response) throws IOException {
                 response.close();
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.restarting), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.restarting), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
         });
     }

--- a/app/src/main/java/com/example/serveradminapp/fragments/UsersFragment.java
+++ b/app/src/main/java/com/example/serveradminapp/fragments/UsersFragment.java
@@ -92,8 +92,10 @@ public class UsersFragment extends Fragment {
         ServerApi.get().listUsers(new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed_load_users), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed_load_users), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override
@@ -116,7 +118,9 @@ public class UsersFragment extends Fragment {
                             userList.add(String.valueOf(item));
                         }
                     }
-                    requireActivity().runOnUiThread(() -> adapter.notifyDataSetChanged());
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() -> adapter.notifyDataSetChanged());
+                    }
                 } catch (JSONException ex) {
                     onFailure(call, new IOException(ex));
                 }
@@ -142,11 +146,13 @@ public class UsersFragment extends Fragment {
                             JSONObject u = users.getJSONObject(i);
                             list.add(u.optString("username"));
                         }
-                        requireActivity().runOnUiThread(() -> {
-                            userList.clear();
-                            userList.addAll(list);
-                            adapter.notifyDataSetChanged();
-                        });
+                        if (isAdded()) {
+                            requireActivity().runOnUiThread(() -> {
+                                userList.clear();
+                                userList.addAll(list);
+                                adapter.notifyDataSetChanged();
+                            });
+                        }
                     }
                 } catch (JSONException ignore) {}
             }
@@ -184,8 +190,10 @@ public class UsersFragment extends Fragment {
             ServerApi.get().createUser(body, new okhttp3.Callback() {
                 @Override
                 public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                    requireActivity().runOnUiThread(() ->
-                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                    if (isAdded()) {
+                        requireActivity().runOnUiThread(() ->
+                                android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                    }
                 }
 
                 @Override
@@ -203,8 +211,10 @@ public class UsersFragment extends Fragment {
         ServerApi.get().deleteUser(username, new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
-                requireActivity().runOnUiThread(() ->
-                        android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                if (isAdded()) {
+                    requireActivity().runOnUiThread(() ->
+                            android.widget.Toast.makeText(requireContext(), getString(R.string.failed), android.widget.Toast.LENGTH_SHORT).show());
+                }
             }
 
             @Override


### PR DESCRIPTION
## Summary
- keep metrics WebSocket alive when restarting activities
- stop socket only when application actually finishes

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68421e70f808832f97f7b0c3feb576fa