### PR TITLE
Fix locale change closing WebSocket

### DIFF
--- a/app/src/main/java/com/example/serveradminapp/LocaleUtil.java
+++ b/app/src/main/java/com/example/serveradminapp/LocaleUtil.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.content.Intent;
 
 import java.util.Locale;
 
@@ -47,11 +46,15 @@ public class LocaleUtil {
         return context;
     }
 
-    /** Restart the given activity to apply configuration changes safely.
-     *  Any active metrics WebSocket is closed so it can be recreated. */
+    /**
+     * Restart the given activity to apply configuration changes without
+     * interrupting the persistent metrics WebSocket connection. Using
+     * {@link Activity#recreate()} triggers a configuration change so the
+     * activity is restarted but {@link Activity#isFinishing()} remains
+     * {@code false}. This prevents {@link MainActivity#onDestroy()} from
+     * closing the WebSocket, keeping it alive during language switches.
+     */
     public static void restart(Activity activity) {
-        Intent intent = activity.getIntent();
-        activity.finish();
-        activity.startActivity(intent);
+        activity.recreate();
     }
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -9,17 +9,45 @@
         android:orientation="vertical"
         android:padding="16dp">
 
-    <EditText
-        android:id="@+id/port_edit"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/port" />
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
 
-    <EditText
-        android:id="@+id/limit_edit"
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/port_label"
+            android:paddingEnd="8dp" />
+
+        <EditText
+            android:id="@+id/port_edit"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/port" />
+    </LinearLayout>
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/daily_limit" />
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/daily_limit_label"
+            android:paddingEnd="8dp" />
+
+        <EditText
+            android:id="@+id/limit_edit"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/daily_limit" />
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -9,17 +9,45 @@
         android:orientation="vertical"
         android:padding="16dp">
 
-    <EditText
-        android:id="@+id/port_edit"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/port" />
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
 
-    <EditText
-        android:id="@+id/limit_edit"
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/port_label"
+            android:paddingEnd="8dp" />
+
+        <EditText
+            android:id="@+id/port_edit"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/port" />
+    </LinearLayout>
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/daily_limit" />
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/daily_limit_label"
+            android:paddingEnd="8dp" />
+
+        <EditText
+            android:id="@+id/limit_edit"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/daily_limit" />
+    </LinearLayout>
 
     <Spinner
         android:id="@+id/lang_spinner"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -8,7 +8,9 @@
     <string name="add_user">Добавить пользователя</string>
     <string name="install">Установить</string>
     <string name="port">Порт</string>
+    <string name="port_label">Порт:</string>
     <string name="daily_limit">Дневной лимит</string>
+    <string name="daily_limit_label">Лимит:</string>
     <string name="save">Сохранить</string>
     <string name="restart_server">Перезапустить сервер</string>
     <string name="model">модель</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,9 @@
     <string name="add_user">Add User</string>
     <string name="install">Install</string>
     <string name="port">Port</string>
+    <string name="port_label">Port:</string>
     <string name="daily_limit">Daily limit</string>
+    <string name="daily_limit_label">Limit:</string>
     <string name="save">Save</string>
     <string name="restart_server">Restart Server</string>
     <string name="model">model</string>


### PR DESCRIPTION
## Summary
- keep metrics WebSocket alive when switching language
- add labels for port and daily limit fields on the settings screen

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68422a6f5324832f893a99d4822e23e0