### PR TITLE
Fix Markdown rendering in chat messages

### DIFF
--- a/app/src/main/java/com/example/serveradminapp/ChatDetailActivity.java
+++ b/app/src/main/java/com/example/serveradminapp/ChatDetailActivity.java
@@ -101,7 +101,7 @@ public class ChatDetailActivity extends AppCompatActivity {
                     final String title = pageTitle;
                     runOnUiThread(() -> {
                         setTitle(title);
-                        view.setText(text);
+                        view.setText(markdownToSpanned(text));
                     });
                 } catch (JSONException ex) {
                     runOnUiThread(() -> view.setText(getString(R.string.error)));


### PR DESCRIPTION
## Summary
- apply Markdown formatting when displaying messages in `ChatDetailActivity`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68429f638214832fbcbd358a3be3ab3c