### PR TITLE
Fix Markdown rendering in chat messages

### DIFF
--- a/app/src/main/java/com/example/serveradminapp/ChatDetailActivity.java
+++ b/app/src/main/java/com/example/serveradminapp/ChatDetailActivity.java
@@ -48,18 +48,21 @@ public class ChatDetailActivity extends AppCompatActivity {
         }
 
         TextView messagesView = findViewById(R.id.messages_text);
+        TextView titleView = findViewById(R.id.chat_title);
+        TextView modelView = findViewById(R.id.chat_model);
+        messagesView.setLineSpacing(0f, 1.2f);
         messagesView.setText(R.string.loading);
 
         View refreshButton = findViewById(R.id.refresh_button);
         View backButton = findViewById(R.id.back_button);
 
-        refreshButton.setOnClickListener(v -> loadMessages(sessionId, messagesView));
+        refreshButton.setOnClickListener(v -> loadMessages(sessionId, messagesView, titleView, modelView));
         backButton.setOnClickListener(v -> finish());
 
-        loadMessages(sessionId, messagesView);
+        loadMessages(sessionId, messagesView, titleView, modelView);
     }
 
-    private void loadMessages(String id, TextView view) {
+    private void loadMessages(String id, TextView view, TextView titleView, TextView modelView) {
         ServerApi.get().getSession(id, new okhttp3.Callback() {
             @Override
             public void onFailure(@NonNull okhttp3.Call call, @NonNull IOException e) {
@@ -81,8 +84,11 @@ public class ChatDetailActivity extends AppCompatActivity {
                     JSONObject obj = new JSONObject(body);
                     String pageTitle = obj.optString("title", obj.optString("session_id"));
                     JSONArray arr = obj.optJSONArray("messages");
+                    String sessionModel = "";
                     StringBuilder sb = new StringBuilder();
                     if (arr != null && arr.length() > 0) {
+                        JSONObject first = arr.getJSONObject(0);
+                        sessionModel = first.optString("model");
                         for (int i = 0; i < arr.length(); i++) {
                             JSONObject m = arr.getJSONObject(i);
                             sb.append(m.optString("username"))
@@ -97,11 +103,13 @@ public class ChatDetailActivity extends AppCompatActivity {
                     }
 
                     final String text = sb.toString();
-
                     final String title = pageTitle;
+                    final String model = sessionModel;
                     runOnUiThread(() -> {
                         setTitle(title);
-                        view.setText(text);
+                        titleView.setText(title);
+                        modelView.setText(model);
+                        view.setText(markdownToSpanned(text));
                     });
                 } catch (JSONException ex) {
                     runOnUiThread(() -> view.setText(getString(R.string.error)));

--- a/app/src/main/res/layout/activity_chat_detail.xml
+++ b/app/src/main/res/layout/activity_chat_detail.xml
@@ -31,6 +31,25 @@
             android:src="@android:drawable/ic_popup_sync" />
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/chat_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="8dp" />
+
+    <TextView
+        android:id="@+id/chat_model"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingBottom="8dp" />
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"


### PR DESCRIPTION
## Summary
- apply Markdown formatting when displaying messages in `ChatDetailActivity`
- show chat title and model in `ChatDetailActivity`
- add line spacing for messages

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68429f638214832fbcbd358a3be3ab3c